### PR TITLE
Removed previous registrations from this computer section

### DIFF
--- a/mff_rams_plugin/templates/preregistration/paid_preregistrations.html
+++ b/mff_rams_plugin/templates/preregistration/paid_preregistrations.html
@@ -1,0 +1,54 @@
+{% extends "./preregistration/preregbase.html" %}
+{% block title %}Preregistraton Successful{% endblock %}
+{% block backlink %}{% endblock %}
+{% block content %}
+<div class="masthead">
+</div>
+
+<div class="panel panel-default">
+<div class="row bs-wizard" style="border-bottom:0;border-top:0;">
+    <div class="col-xs-4 bs-wizard-step complete">
+      <div class="text-center bs-wizard-stepnum">Step 1</div>
+      <div class="progress"><div class="progress-bar"></div></div>
+      <a class="bs-wizard-dot"></a>
+      <div class="bs-wizard-info text-center">Enter Info</div>
+    </div>
+    <div class="col-xs-4 bs-wizard-step complete">
+      <div class="text-center bs-wizard-stepnum">Step 2</div>
+      <div class="progress"><div class="progress-bar"></div></div>
+      <a class="bs-wizard-dot"></a>
+      <div class="bs-wizard-info text-center">Review &amp; Pay</div>
+    </div>
+    <div class="col-xs-4 bs-wizard-step active">
+      <div class="text-center bs-wizard-stepnum">Step 3</div>
+      <div class="progress"><div class="progress-bar"></div></div>
+      <a class="bs-wizard-dot"></a>
+      <div class="bs-wizard-info text-center">Done</div>
+    </div>
+</div>
+
+
+<div class="row">
+  <div class="well col-md-offset-1 col-md-10">
+    <h1>Registration Complete</h1>
+    <p>
+      Congratulations! Your registration was successful.
+    </p>
+    <p>
+      Your credit card was successfully charged for
+      <strong>${{ total_cost }}</strong>, and you will receive a confirmation
+      email sent to you shortly. If you paid for other registrations, those
+      attendees will get their own confirmation email.
+    </p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-offset-1 col-md-10">
+    <a href="index">
+      <button class="btn btn-primary">Add Another Registration</button>
+    </a>
+
+{% include "preregistration/disclaimers.html" %}
+
+{% endblock %}


### PR DESCRIPTION
Addresses one of the complaints about the "long session cookie" or whatever.  Kills off the list of prior regs from the computer, which should prevent attendees from accessing someone else's reg if they use the same machine (let's assume most likely scenario is mischievous roommates).

Fixes https://github.com/MidwestFurryFandom/rams/issues/128