### PR TITLE
Display badge price correctly

### DIFF
--- a/mff_rams_plugin/templates/preregistration/attendee_donation_form.html
+++ b/mff_rams_plugin/templates/preregistration/attendee_donation_form.html
@@ -8,7 +8,7 @@
 {% if attendee.paid == c.NOT_PAID or attendee.overridden_price %}
     <h2> Badge Payment for {{ attendee.full_name }} </h2>
 
-    You've registered for {{ c.EVENT_NAME }} at a {% if attendee.overridden_price %}discounted{% endif %} price of ${{ attendee.overridden_price|default(attendee.badge_cost|round(2)) }}{% if attendee.amount_extra %} and you've also kicked in ${{ attendee.amount_extra|round(2) }}{% endif %}; your total outstanding balance is ${{ attendee.amount_unpaid|round(2) }}.
+    You've registered for {{ c.EVENT_NAME }} at a {% if attendee.overridden_price %}discounted{% endif %} price of ${{ attendee.badge_cost }}{% if attendee.amount_extra %} and you've also kicked in ${{ attendee.amount_extra|round(2) }}{% endif %}; your total outstanding balance is ${{ attendee.amount_unpaid|round(2) }}.
 
     <table style="width:auto ; margin-left:auto ; margin-right: auto"><tr>
         <td>{{ stripe_form('process_attendee_donation',charge) }}</td>


### PR DESCRIPTION
Jinja2 (for some reason) doesn't count None as falsey in certain cases, so prints out "None" when an attendee doesn't have an overridden price. We've updated the badge_cost property to accommodate 'overridden price' anyway, so we just have to fix the page display.

Fixes https://github.com/MidwestFurryFandom/art_show/issues/16.