### PR TITLE
Make 'print pending' text instead of a checkbox

### DIFF
--- a/mff_rams_plugin/templates/regextra.html
+++ b/mff_rams_plugin/templates/regextra.html
@@ -9,7 +9,7 @@
         <div id="print_pending" class="form-group">
             <label for="print_pending" class="col-sm-2 control-label">Ready to Print</label>
             <div class="col-sm-6">
-                {{ macros.checkbox(attendee, 'print_pending') }}
+                {{ attendee.print_pending|yesno }}
             </div>
         </div>
     {% endif %}


### PR DESCRIPTION
There were reports of volunteers accidentally setting print_pending back to True after a badge was printed. It's not super clear why this is happening, but one possible cause is that a page is loaded while print_pending is true, the badge gets sent to the printer, and then the checkbox is updating the attendee when a page is saved. This removes the checkbox so that no longer can happen.