### PR TITLE
Configure MFF to replace promo codes with agent codes

### DIFF
--- a/mff_rams_plugin/model_checks.py
+++ b/mff_rams_plugin/model_checks.py
@@ -3,6 +3,7 @@ import re
 from uber.decorators import prereg_validation, validation
 from uber.config import c
 from uber.model_checks import ignore_unassigned_and_placeholders
+from uber.models import Session
 
 
 @validation.Attendee
@@ -68,3 +69,13 @@ def power_usage(group):
     if group.power and not group.power_usage:
         return 'Please provide a list of what powered devices you ' \
                'expect to use.'
+
+
+@prereg_validation.Attendee
+def promo_code_is_useful(attendee):
+    if attendee.promo_code:
+        with Session() as session:
+            if session.lookup_agent_code(attendee.promo_code.code):
+                return
+            else:
+                return 'Invalid agent code'

--- a/mff_rams_plugin/templates/baseextra.html
+++ b/mff_rams_plugin/templates/baseextra.html
@@ -1,4 +1,12 @@
-
+{% if c.PAGE_PATH == '/preregistration/index' %}
+    <script type="text/javascript">
+        $(function () {
+            $('li:contains("promo code")').each(function() {
+                $(this).remove();
+            });
+        });
+    </script>
+{% endif %}
 
 {% if c.PAGE_PATH == '/registration/form' %}
     <script type="text/javascript">

--- a/mff_rams_plugin/templates/regextra.html
+++ b/mff_rams_plugin/templates/regextra.html
@@ -69,7 +69,7 @@
         // Increase maximum length of badge_printed_name and make it bold
         $.field('badge_printed_name').prop('maxlength', 30);
         $("label[for='badge_printed_name']").removeClass('optional-field');
-        $('p:contains("Badge names have a maximum of 20 characters.")').text("Badge names have a maximum of 30 characters.")
+        $('p:contains("Badge names have a maximum of 20 characters.")').text("Badge names have a maximum of 30 characters.");
     });
 
     // We don't use amount_extra so we don't want this to do anything
@@ -78,6 +78,12 @@
     // We don't want attendees to be able to invalidate themselves
     if ($("[form='invalidate']").length) {
         $("[form='invalidate']").remove()
+    }
+
+    // No promo codes! Agent codes!
+    if ($.field('promo_code')) {
+        $("label[for='promo_code']").text("Agent Code");
+        $.field('promo_code').attr("placeholder", "A code from an artist to assign you as their agent");
     }
 </script>
 


### PR DESCRIPTION
The art show plugin (theoretically) allows both promo code use and agent code use, but MFF only needs the latter, so we want to change some cosmetic things to reflect that.