### PR TITLE
Make dealer's due date configurable

### DIFF
--- a/mff_rams_plugin/automated_emails.py
+++ b/mff_rams_plugin/automated_emails.py
@@ -13,6 +13,6 @@ MarketplaceEmailFixture(
 MarketplaceEmailFixture(
     'Last chance to pay for your {EVENT_NAME} ({EVENT_DATE}) Dealer registration',
     'dealers/payment_reminder.txt',
-    lambda g: g.status == c.APPROVED and days_before(7, g.dealer_payment_due, 2)() and g.is_unpaid,
+    lambda g: g.status == c.APPROVED and days_before(2, g.dealer_payment_due)() and g.is_unpaid,
     needs_approval=False,
     ident='dealer_reg_payment_reminder_last_chance_mff')

--- a/mff_rams_plugin/configspec.ini
+++ b/mff_rams_plugin/configspec.ini
@@ -1,6 +1,9 @@
 publications_email = string(default="Midwest Furfest Publications <publications@furfest.org>")
 business_license_url = string(default="http://www.revenue.state.il.us/Businesses/register.htm")
 
+# How many days after approval a dealer has to pay
+dealer_payment_days = integer(default='14')
+
 # Dealers have the option to request a power drop at their table.
 [power_prices]
 0 = integer(default='0')

--- a/mff_rams_plugin/models.py
+++ b/mff_rams_plugin/models.py
@@ -52,7 +52,7 @@ class Group:
     @property
     def dealer_payment_due(self):
         if self.approved:
-            return self.approved + timedelta(44)
+            return self.approved + timedelta(c.DEALER_PAYMENT_DAYS)
 
     @property
     def dealer_payment_is_late(self):


### PR DESCRIPTION
Adds `dealer_payments_days` to this plugin's config file, so we can change how long dealers have to pay if we need to.