### PR TITLE
Added targets to disclaimer links

### DIFF
--- a/mff_rams_plugin/templates/preregistration/disclaimers.html
+++ b/mff_rams_plugin/templates/preregistration/disclaimers.html
@@ -3,11 +3,11 @@
 
 <div style="font-weight:bold ; color:red ; margin-bottom:5px">Disclaimers:</div>
 <ul>
-<li> Please review our frequently asked questions on the <a href="https://www.furfest.org/registration">registration page</a> prior to purchasing your badge for important information. </li>
+<li> Please review our frequently asked questions on the <a href="https://www.furfest.org/registration" target="_blank">registration page</a> prior to purchasing your badge for important information. </li>
 {% if not c.AT_THE_CON %}<li> If you don't pay for your registration, it will be deleted and you will have to pay full price at the door.</li>
 <li> Your registration is refundable until the close of preregistration on Nov 17, 2017. Please <a href="mailto:registration@furfest.org">contact registration</a> to request a refund before that date. Refunds can only be processed to the purchasing card. </li>{% endif %}
 <li> Midwest Furfest has a one badge per person policy. If you purchase multiple badges (for your family, friend, or as a gift), please ensure that each badge is purchased in the name of the individual who the badge is intended for. You may use the same email address for multiple badges so any surprises aren't ruined. The purchaser retains sole ownership of the badge until the end of preregistration and may request a refund of a purchased badge.</li>
-<li> All attendees must abide by our <a href="https://www.furfest.org/code-of-conduct">code of conduct</a>.</li>
+<li> All attendees must abide by our <a href="https://www.furfest.org/code-of-conduct" target="_blank">code of conduct</a>.</li>
     {% if c.CONSENT_FORM_URL %}
   <li> Attendees under 18 MUST bring a signed and notarized parental consent form if not accompanied by parent or guardian during badge pickup. Also, any attendee under the age of 17 must be with their parent or other guardian while on site. Please see our registration FAQ for more information. Failure to have a proper permission paperwork filled out will prevent you from receiving your badge.</li>
     {% endif %}


### PR DESCRIPTION
Disclaimer has two links to websites and we want those to come up in a new window attendees don't screw up their reg.