### PR TITLE
Altered refs to refundable badges to be nonrefundable

### DIFF
--- a/mff_rams_plugin/templates/emails/reg_workflow/attendee_confirmation.html
+++ b/mff_rams_plugin/templates/emails/reg_workflow/attendee_confirmation.html
@@ -17,7 +17,6 @@ Badges are not mailed out before the event, so your badge will be available for 
 
 {% include "emails/reg_workflow/reg_notes.html" %}
 
-Your registration may be cancelled and refunded until preregistration closes on Friday, November 17, 2017. Please email registration@furfest.org to request a cancellation and refund.
 <br><br>
 If you have any other questions about your registration, please email us at registration@furfest.org. Thank you for again registering for Midwest FurFest and we’ll see you at the con.
 <br><br>

--- a/mff_rams_plugin/templates/preregistration/disclaimers.html
+++ b/mff_rams_plugin/templates/preregistration/disclaimers.html
@@ -5,7 +5,8 @@
 <ul>
 <li> Please review our frequently asked questions on the <a href="https://www.furfest.org/registration" target="_blank">registration page</a> prior to purchasing your badge for important information. </li>
 {% if not c.AT_THE_CON %}<li> If you don't pay for your registration, it will be deleted and you will have to pay full price at the door.</li>
-<li> Your registration is refundable until the close of preregistration on Nov 17, 2017. Please <a href="mailto:registration@furfest.org">contact registration</a> to request a refund before that date. Refunds can only be processed to the purchasing card. </li>{% endif %}
+<li><span style="font-weight:bold ; color:red">Purchased registration are non-refundable.</span> Please <a href="mailto:registration@furfest.org">contact registration</a> for other options before the close of preregistration on {{c.PREREG_TAKEDOWN|datetime_local}}.</li>
+{% endif %}
 <li> Midwest Furfest has a one badge per person policy. If you purchase multiple badges (for your family, friend, or as a gift), please ensure that each badge is purchased in the name of the individual who the badge is intended for. You may use the same email address for multiple badges so any surprises aren't ruined. The purchaser retains sole ownership of the badge until the end of preregistration and may request a refund of a purchased badge.</li>
 <li> All attendees must abide by our <a href="https://www.furfest.org/code-of-conduct" target="_blank">code of conduct</a>.</li>
     {% if c.CONSENT_FORM_URL %}


### PR DESCRIPTION
Badges are no longer refundable, and now our pages reflect that.