### PR TITLE
Update refund wording

### DIFF
--- a/mff_rams_plugin/templates/emails/reg_workflow/attendee_confirmation.html
+++ b/mff_rams_plugin/templates/emails/reg_workflow/attendee_confirmation.html
@@ -17,7 +17,7 @@ Badges are not mailed out before the event, so your badge will be available for 
 
 {% include "emails/reg_workflow/reg_notes.html" %}
 
-Your registration may be cancelled and refunded until preregistration closes at {{ c.PREREG_TAKEDOWN|datetime_local }}. Please email registration@furfest.org to request a cancellation and refund.
+You may cancel your registration and receive a refund at any time until preregistration closes at {{ c.PREREG_TAKEDOWN|datetime_local }}. Please email registration@furfest.org to request a cancellation and refund.
 <br/><br/>
 If you have any other questions about your registration, please email us at registration@furfest.org. Thank you for again registering for Midwest FurFest and we’ll see you at the con.
 <br/><br/>


### PR DESCRIPTION
Blithe had some input on cleaning up the wording (nixing passive voice) and we've cleaned it up a bit as a result. Just hits the email. The disclaimers page was already consistent with this.