### PR TITLE
Added an export that includes categories

### DIFF
--- a/mff_rams_plugin/site_sections/mff_reports.py
+++ b/mff_rams_plugin/site_sections/mff_reports.py
@@ -1,7 +1,6 @@
 from uber.config import c
-from uber.decorators import all_renderable
-from uber.models import Attendee
-
+from uber.decorators import all_renderable, csv_file
+from uber.models import Attendee, Group
 
 @all_renderable(c.PEOPLE)
 class Root:
@@ -28,3 +27,54 @@ class Root:
             'unclaimed_comped': unclaimed_comped.count(),
             'show': show
         }
+
+    @csv_file
+    def all_dealers_detailed(self, out, session ):
+        out.writerow([
+            'Business Name',
+            'Dealer Name',
+            'Status',
+            'Description',
+            'URL',
+            'Point of Contact',
+            'Email',
+            'Phone Number',
+            'Address1',
+            'Address2',
+            'City',
+            'State/Region',
+            'Zip Code',
+            'Country',
+            'Tables',
+            'Amount Paid',
+            'Cost',
+            'Badges',
+            'Wares',
+            'Wares - Other'
+        ])
+        dealer_groups = session.query(Group).filter(Group.tables > 0).all()
+        for group in dealer_groups:
+            if group.is_dealer:
+                full_name = group.leader.full_name if group.leader else ''
+                out.writerow([
+                    group.name,
+                    full_name,
+                    group.status_label,
+                    group.description,
+                    group.website,
+                    group.leader.legal_name or group.leader.full_name,
+                    group.leader.email,
+                    group.leader.cellphone,
+                    group.address1,
+                    group.address2,
+                    group.city,
+                    group.region,
+                    group.zip_code,
+                    group.country,
+                    group.tables,
+                    group.amount_paid,
+                    group.cost,
+                    group.badges,
+                    group.categories_labels,
+                    group.categories_text
+                ])


### PR DESCRIPTION
Adds a bunch of options in a new report on the mff-rams-plugin section of the sitemap. It's more an object export than a table export, but I think that does what we want. Alternately we could tweak the report that's down in summary. I'm not sure what the most-right answer is.

fixes #33 