### PR TITLE
Stop model-checking admin changes to dealers

### DIFF
--- a/mff_rams_plugin/model_checks.py
+++ b/mff_rams_plugin/model_checks.py
@@ -71,7 +71,7 @@ def power_usage(group):
                'expect to use.'
 
 
-@validation.Group
+@prereg_validation.Group
 def no_edit_post_approval(group):
     if group.status == c.APPROVED:
         no_change = []


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/mff-rams-plugin/issues/65 (part 1). We also need https://github.com/MidwestFurryFandom/rams/pull/257, since the model checks fall back to the core plugin in this case.