### PR TITLE
Remove broken clientside anti-emoji validation

### DIFF
--- a/mff_rams_plugin/templates/baseextra.html
+++ b/mff_rams_plugin/templates/baseextra.html
@@ -32,9 +32,5 @@
             $("form[action*='lost_badge']").remove();
         }
 
-        $("input").each(function() {
-            $(this).prop('pattern','[^\u{1F600}-\u{1F6FF}]*').prop('title','No fields may contain emoji characters.');
-        });
-
     });
 </script>


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/rams/issues/231. We had been trying to prevent attendees from entering emoji into fields, but it turns out that this stopped working at some point. We still have serverside validation, so while it's a little less user-friendly, we'll just use that.