### PR TITLE
Add break-word wrapping to badge printing page

### DIFF
--- a/mff_rams_plugin/templates/kiosk_printing/print_badges.html
+++ b/mff_rams_plugin/templates/kiosk_printing/print_badges.html
@@ -59,9 +59,12 @@ body {margin: 0; padding: 0;}
 	height: 200px;
 }
 #badge_name {
-	display: table-cell;
+	display: block;
+  width: 800px;
 	vertical-align: middle;
 	height: 100%;
+  word-wrap: break-word;
+  white-space: normal;
 }
 #daily-row {
 	display: block;


### PR DESCRIPTION
This will need to be tested with a printer, since I had to change the `display` property to get it to work. Fixes https://github.com/MidwestFurryFandom/rams/issues/207 by forcing a line break for very long badge name.