### PR TITLE
Unremove Art Show incomplete_reason override

### DIFF
--- a/mff_rams_plugin/models.py
+++ b/mff_rams_plugin/models.py
@@ -20,16 +20,6 @@ class SessionMixin:
 
 
 @Session.model_mixin
-class ArtShowApplication:
-    @property
-    def incomplete_reason(self):
-        if self.status != c.APPROVED:
-            return self.status_label
-        if self.attendee.badge_status == c.NEW_STATUS:
-            return "Missing registration info"
-
-
-@Session.model_mixin
 class Group:
     power = Column(Integer, default=0)
     power_fee = Column(Integer, default=0)


### PR DESCRIPTION
For some reason this was only present in master, causing staging to work as expected and master to... not.

Fixes https://github.com/MidwestFurryFandom/art_show/issues/229.