### PR TITLE
Override default number of max dealer badges

### DIFF
--- a/mff_rams_plugin/templates/groupextra.html
+++ b/mff_rams_plugin/templates/groupextra.html
@@ -1,4 +1,17 @@
 <script type="text/javascript">
+    {% if not c.MAX_DEALERS %}
+    updateBadgeMax = function() {
+        var new_badge_max = Math.min(Math.ceil(parseFloat($("select[name=tables]").val())) * 3, 12);
+        var curr_badge_max = parseInt($('select[name=badges] option:last').val()) || 0;
+        if (curr_badge_max > new_badge_max) {
+            $("select[name=badges] option").slice(new_badge_max, curr_badge_max).remove();
+        } else {
+            for (i = curr_badge_max+1; i < new_badge_max+1; i++) {
+                $("select[name=badges]").append('<option value="'+i+'">'+i+'</option>');
+            }
+        }
+    };
+    {% endif %}
     $(function () {
         // Position new field(s)
         if ($('#power-fields').length) {


### PR DESCRIPTION
When MAX_DEALERS is set to 0, we default to letting dealers buy badges equal to the number of tables they buy + 1. MFF wants a different number (3 per table, up to 12), so this overrides the appropriate properties and JS.

This also depends on https://github.com/MidwestFurryFandom/rams/pull/299.