### PR TITLE
Add fursuiting check to prereg

### DIFF
--- a/alembic/versions/0f7426266803_add_fursuiting_column.py
+++ b/alembic/versions/0f7426266803_add_fursuiting_column.py
@@ -1,0 +1,59 @@
+"""Add fursuiting column
+
+Revision ID: 0f7426266803
+Revises: 1da162016924
+Create Date: 2019-07-11 20:34:39.406286
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '0f7426266803'
+down_revision = '1da162016924'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except Exception:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.add_column('attendee', sa.Column('fursuiting', sa.Integer(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('attendee', 'fursuiting')

--- a/mff_rams_plugin/configspec.ini
+++ b/mff_rams_plugin/configspec.ini
@@ -8,3 +8,8 @@ dealer_payment_days = integer(default='14')
 [power_prices]
 0 = integer(default='0')
 1 = integer(default='40')
+
+[enums]
+[[fursuiting]]
+suit = string(default="Yes")
+no_suit = string(default="No")

--- a/mff_rams_plugin/model_checks.py
+++ b/mff_rams_plugin/model_checks.py
@@ -5,6 +5,12 @@ from uber.config import c
 from uber.model_checks import ignore_unassigned_and_placeholders
 
 
+@prereg_validation.Attendee
+def need_fursuit_option(attendee):
+    if not attendee.fursuiting:
+        return "Please tell us if you are planning to suit or not."
+
+
 @validation.Attendee
 def need_comped_reason(attendee):
     if attendee.paid == c.NEED_NOT_PAY and not attendee.comped_reason:

--- a/mff_rams_plugin/models.py
+++ b/mff_rams_plugin/models.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from uber.models import Session
 from uber.config import c
 from uber.utils import localized_now, localize_datetime
-from uber.models.types import DefaultColumn as Column
+from uber.models.types import Choice, DefaultColumn as Column
 from uber.decorators import cost_property, presave_adjustment
 
 
@@ -81,6 +81,7 @@ class Group:
 @Session.model_mixin
 class Attendee:
     comped_reason = Column(UnicodeText, default='', admin_only=True)
+    fursuiting = Column(Choice(c.FURSUITING_OPTS))
 
     @presave_adjustment
     def save_group_cost(self):

--- a/mff_rams_plugin/templates/regextra.html
+++ b/mff_rams_plugin/templates/regextra.html
@@ -100,4 +100,4 @@
     });
 </script>
 
-{{ macros.form_group(attendee, 'fursuiting', type='radio_buttons', label="Do you plan on fursuiting at " + c.EVENT_NAME + "?", help="This is just to help us prepare, it's okay if your plans change!", is_required=True) }}
+{{ macros.form_group(attendee, 'fursuiting', type='radio_buttons', label="Do you plan on fursuiting at " + c.EVENT_NAME + "?", help="This is just to help us prepare; it's okay if your plans change!", is_required=True) }}

--- a/mff_rams_plugin/templates/regextra.html
+++ b/mff_rams_plugin/templates/regextra.html
@@ -93,7 +93,7 @@
     }
 
     if ($(':radio[name=fursuiting]')) {
-        $(':radio[name=fursuiting]').parents('.form-group').insertBefore($.field('promo_code').parents('.form-group'));
+        $(':radio[name=fursuiting]').removeAttr('required').parents('.form-group').insertBefore($.field('promo_code').parents('.form-group'));
         $(":radio[value={{ c.NO_SUIT }}]").parents('label').removeClass('btn-default').addClass('btn-danger');
         $(":radio[value={{ c.SUIT }}]").parents('label').removeClass('btn-default').addClass('btn-success');
     }

--- a/mff_rams_plugin/templates/regextra.html
+++ b/mff_rams_plugin/templates/regextra.html
@@ -1,3 +1,4 @@
+{%- import 'macros.html' as macros -%}
 {% if c.PAGE_PATH == '/registration/form' %}
     {% if attendee.times_printed < 1 or attendee.print_pending %}
         <script type="text/javascript">
@@ -75,7 +76,6 @@
         $.field('badge_printed_name').prop('maxlength', 30);
         $("label[for='badge_printed_name']").removeClass('optional-field');
         $('p:contains("Badge names have a maximum of 20 characters.")').text("Badge names have a maximum of 30 characters.");
-    });
 
     // We don't use amount_extra so we don't want this to do anything
     donationChanged = function() {};
@@ -91,6 +91,13 @@
         $.field('promo_code').attr("placeholder", "A discount code or an agent code");
         $('<p class="help-text"><em>If you have a discount code, enter it now. Agent codes may be added via the link you receive in your confirmation email.</em></p>').insertAfter($.field('promo_code'));
     }
+
+    if ($(':radio[name=fursuiting]')) {
+        $(':radio[name=fursuiting]').parents('.form-group').insertBefore($.field('promo_code').parents('.form-group'));
+        $(":radio[value={{ c.NO_SUIT }}]").parents('label').removeClass('btn-default').addClass('btn-danger');
+        $(":radio[value={{ c.SUIT }}]").parents('label').removeClass('btn-default').addClass('btn-success');
+    }
+    });
 </script>
 
-{# {% include 'art_show_link.html' %} #}
+{{ macros.form_group(attendee, 'fursuiting', type='radio_buttons', label="Do you plan on fursuiting at " + c.EVENT_NAME + "?", help="This is just to help us prepare, it's okay if your plans change!", is_required=True) }}


### PR DESCRIPTION
Adds a set of radio buttons to see if attendees are planning on fursuiting.

The buttons currently look like this:
![image](https://user-images.githubusercontent.com/7198215/61085410-2fc57080-a3fe-11e9-9cd9-916d09fae88e.png)

Neither "No" or "Yes" is selected in that screenshot. Unfortunately, having only two options makes it ambiguous and people may not realize that. We may want to instead have "No/Yes/Not Sure" just to make the UI a little more clear. We can also change the colors of the buttons.

We will also probably want more formal wording for the explanation.