### PR TITLE
Restored mig dependency on main marketplace mig

### DIFF
--- a/alembic/versions/f08f4606351c_add_tax_number_column_for_marketplace_.py
+++ b/alembic/versions/f08f4606351c_add_tax_number_column_for_marketplace_.py
@@ -11,7 +11,7 @@ Create Date: 2019-08-27 23:57:55.936896
 revision = 'f08f4606351c'
 down_revision = '0f7426266803'
 branch_labels = None
-depends_on = None
+depends_on = '9e721eb0b45c'
 
 from alembic import op
 import sqlalchemy as sa


### PR DESCRIPTION
Just what it says on the tin: restore an alembic migration dependency that we removed in testing but turned out to be important for migrating staging (and probably prod).