### PR TITLE
Fix attendee-facing art show app page

### DIFF
--- a/mff_rams_plugin/templates/art_show_applications/edit.html
+++ b/mff_rams_plugin/templates/art_show_applications/edit.html
@@ -20,8 +20,6 @@
           Before completing your application, please finish filling out your information
           <a href="../preregistration/confirm?id={{ app.attendee_id }}" target="_blank">here</a>. Afterwards, you will
           be able to pay for your application on this page.
-        {% elif app.delivery_method == c.BY_MAIL and not app.address1 %}
-          Please fill in your mailing address below. Afterwards, you will be able to pay for your application on this page.
         {% else %}
         <br/><br/>{% include 'art_pieces_form.html' %}
         {% endif %}

--- a/mff_rams_plugin/templates/art_show_applications/edit.html
+++ b/mff_rams_plugin/templates/art_show_applications/edit.html
@@ -2,23 +2,28 @@
 {% block title %}Art Show Application{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}
+<script type="text/javascript">{% include "region_opts.html" %}</script>
 <div class="masthead"></div>
 <div class="panel panel-default">
   <div class="panel-body">
     <h2>{{ c.EVENT_NAME }} Art Show Application</h2>
-      {% if app.status == c.APPROVED %}
-      Congratulations, your application has been approved!
+      {% if app.status in [c.APPROVED, c.PAID] %}
+        {% if app.status == c.APPROVED %}Congratulations, your application has been approved!{% endif %}
         {% if not app.incomplete_reason and app.is_unpaid %}
           In order to complete your application, please pay ${{ app.attendee.amount_unpaid }} using the button below.
           {% if app.attendee.badge_cost %}This total includes the cost of your badge, if you have not paid for it
-          already.{% endif %}<br/>
+          already.{% endif %}<br/><br/>
           <div style="text-align:center">
               {{ stripe_form('process_art_show_payment', charge) }}
           </div><br/><br/>
-        {% elif app.attendee.badge_status == c.NEW_STATUS %}
+        {% elif app.attendee.placeholder and app.attendee.badge_status != c.NOT_ATTENDING %}
           Before completing your application, please finish filling out your information
           <a href="../preregistration/confirm?id={{ app.attendee_id }}" target="_blank">here</a>. Afterwards, you will
           be able to pay for your application on this page.
+        {% elif app.delivery_method == c.BY_MAIL and not app.address1 %}
+          Please fill in your mailing address below. Afterwards, you will be able to pay for your application on this page.
+        {% else %}
+        <br/><br/>{% include 'art_pieces_form.html' %}
         {% endif %}
       {% elif app.status != c.UNAPPROVED %}
       Unfortunately, since your application has been {{ app.status_label|lower }}, you may no longer edit it. However,


### PR DESCRIPTION
There were differences between this template and the current template in art_show, and this version had a few bugs in the logic. I've replaced it with the template in art_show and re-removed the mailing address form (which is why we're overriding this template in the first place).