### PR TITLE
Make incomplete_reason agree with template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+.vscode/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/alembic/versions/f08f4606351c_add_tax_number_column_for_marketplace_.py
+++ b/alembic/versions/f08f4606351c_add_tax_number_column_for_marketplace_.py
@@ -11,7 +11,7 @@ Create Date: 2019-08-27 23:57:55.936896
 revision = 'f08f4606351c'
 down_revision = '0f7426266803'
 branch_labels = None
-depends_on = '9e721eb0b45c'
+depends_on = None
 
 from alembic import op
 import sqlalchemy as sa

--- a/mff_rams_plugin/models.py
+++ b/mff_rams_plugin/models.py
@@ -29,7 +29,7 @@ class ArtShowApplication:
     def incomplete_reason(self):
         if self.status != c.APPROVED:
             return self.status_label
-        if self.attendee.badge_status == c.NEW_STATUS:
+        if self.attendee.placeholder and self.attendee.badge_status != c.NOT_ATTENDING:
             return "Missing registration info"
 
 


### PR DESCRIPTION
Fixes https://jira.furfest.org/browse/SEI_SD-121 -- the incomplete_reason for the art show app had different conditions than the template that relied on it, causing them to disagree on whether the attendee needed to pay or not.