### PR TITLE
Count 'paid' apps as complete

### DIFF
--- a/mff_rams_plugin/models.py
+++ b/mff_rams_plugin/models.py
@@ -27,7 +27,7 @@ class SessionMixin:
 class ArtShowApplication:
     @property
     def incomplete_reason(self):
-        if self.status != c.APPROVED:
+        if self.status not in [c.APPROVED, c.PAID]:
             return self.status_label
         if self.attendee.placeholder and self.attendee.badge_status != c.NOT_ATTENDING:
             return "Missing registration info"


### PR DESCRIPTION
This was a regression bug that was preventing artists from paying, and making piece counts not show up in the admin list of applications.