### PR TITLE
Cache AT_THE_DOOR_BADGE_OPTS to improve performance

### DIFF
--- a/mff_rams_plugin/config.py
+++ b/mff_rams_plugin/config.py
@@ -1,4 +1,4 @@
-from sideboard.lib import parse_config
+from sideboard.lib import parse_config, request_cached_property
 from collections import defaultdict
 from datetime import timedelta
 
@@ -72,7 +72,7 @@ class ExtraConfig:
     def DEALER_POWER_OPTS(self):
         return [(0, 'No power'), (1, 'Default power')]
 
-    @property
+    @request_cached_property
     @dynamic
     def AT_THE_DOOR_BADGE_OPTS(self):
         """


### PR DESCRIPTION
This property is complex and checks the database multiple times for badge availability, and was being called multiple times in a pageload. We now cache the property per pageload, reducing the load time of /registration/register from ~11 seconds to ~2.