### PR TITLE
Update MFF plugin for the latest version of RAMS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ ENV/
 
 #OS Weirdness
 **/*.DS_Store
+
+# VSCode
+.history/

--- a/mff_rams_plugin/config.py
+++ b/mff_rams_plugin/config.py
@@ -10,31 +10,31 @@ config = parse_config(__file__)
 c.include_plugin_config(config)
 
 c.MENU.append_menu_item(
-    MenuItem(name='Midwest FurFest', access=c.PEOPLE, submenu=[
+    MenuItem(name='Midwest FurFest', submenu=[
         MenuItem(name='Comped Badges', href='../mff_reports/comped_badges'),
         MenuItem(name='Daily Attendance', href='../mff_reports/attendance_graph'),
         MenuItem(name='Print Adult Badges (Single Queue)',
-                 href='../kiosk_printing/print_badges'),
+                 href='../badge_printing/print_next_badge'),
         MenuItem(name='Print Adult Badges (1 of 2)',
-                 href='../kiosk_printing/print_badges?printerNumber=1&numberOfPrinters=2'),
+                 href='../badge_printing/print_next_badge?printerNumber=1&numberOfPrinters=2'),
         MenuItem(name='Print Adult Badges (2 of 2)',
-                 href='../kiosk_printing/print_badges?printerNumber=2&numberOfPrinters=2'),
+                 href='../badge_printing/print_next_badge?printerNumber=2&numberOfPrinters=2'),
         MenuItem(name='Print Adult Badges (1 of 3)',
-                 href='../kiosk_printing/print_badges?printerNumber=1&numberOfPrinters=3'),
+                 href='../badge_printing/print_next_badge?printerNumber=1&numberOfPrinters=3'),
         MenuItem(name='Print Adult Badges (2 of 3)',
-                 href='../kiosk_printing/print_badges?printerNumber=2&numberOfPrinters=3'),
+                 href='../badge_printing/print_next_badge?printerNumber=2&numberOfPrinters=3'),
         MenuItem(name='Print Adult Badges (3 of 3)',
-                 href='../kiosk_printing/print_badges?printerNumber=3&numberOfPrinters=3'),
+                 href='../badge_printing/print_next_badge?printerNumber=3&numberOfPrinters=3'),
         MenuItem(name='Print Adult Badges (1 of 4)',
-                 href='../kiosk_printing/print_badges?printerNumber=1&numberOfPrinters=4'),
+                 href='../badge_printing/print_next_badge?printerNumber=1&numberOfPrinters=4'),
         MenuItem(name='Print Adult Badges (2 of 4)',
-                 href='../kiosk_printing/print_badges?printerNumber=2&numberOfPrinters=4'),
+                 href='../badge_printing/print_next_badge?printerNumber=2&numberOfPrinters=4'),
         MenuItem(name='Print Adult Badges (3 of 4)',
-                 href='../kiosk_printing/print_badges?printerNumber=3&numberOfPrinters=4'),
+                 href='../badge_printing/print_next_badge?printerNumber=3&numberOfPrinters=4'),
 		MenuItem(name='Print Adult Badges (4 of 4)',
-                 href='../kiosk_printing/print_badges?printerNumber=4&numberOfPrinters=4'),
+                 href='../badge_printing/print_next_badge?printerNumber=4&numberOfPrinters=4'),
 		MenuItem(name='Print Minor Badges',
-                 href='../kiosk_printing/print_badges?minor=True'),
+                 href='../badge_printing/print_next_badge?minor=True'),
     ])
 )
 

--- a/mff_rams_plugin/site_sections/mff_reports.py
+++ b/mff_rams_plugin/site_sections/mff_reports.py
@@ -121,7 +121,7 @@ class RegistrationDataOneYear:
             "event_end_date": self.end_date.strftime("%d-%m-%Y"),
         }
 
-@all_renderable(c.PEOPLE, c.STATS)
+@all_renderable()
 class Root:
     def index(self, session):
         pass

--- a/mff_rams_plugin/templates/baseextra.html
+++ b/mff_rams_plugin/templates/baseextra.html
@@ -16,7 +16,7 @@
     </script>
 
     <div id="reprint_fee" class="form-group">
-    {% include "kiosk_printing/reprint_fee.html" %}
+    {% include "badge_printing/reprint_fee.html" %}
     </div>
 {% endif %}
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ if __name__ == '__main__':
         description='Sideboard ' + pkg_name + ' plugin',
         license='AGPL v3 or later',
         scripts=[],
-        setup_requires=['distribute'],
         install_requires=requires,
         packages=find_packages(),
         include_package_data=True,


### PR DESCRIPTION
Changes URLs to match the new integrated badge_printing plugin and removes references to outdated permissions settings.