### PR TITLE
Added space to keep the and from the end of the reg code

### DIFF
--- a/mff_rams_plugin/templates/emails/reg_workflow/attendee_confirmation.html
+++ b/mff_rams_plugin/templates/emails/reg_workflow/attendee_confirmation.html
@@ -9,7 +9,7 @@ You ({{ attendee.full_name }}) have preregistered for {{ c.EVENT_NAME }} at the 
     and your payment of {{ (attendee.amount_paid / 100)|format_currency }} has been received.  
 {% endif %}
 <br/><br/>
-Your registration confirmation number is {{ attendee.id }}{% if c.ATTENDEE_ACCOUNTS_ENABLED %}
+Your registration confirmation number is {{ attendee.id }} {% if c.ATTENDEE_ACCOUNTS_ENABLED %}
 {% if attendee.email != attendee.managers[0].email %}
 and your registration has been processed under account {{ attendee.managers[0].id }} ({{ attendee.managers[0].email }}).
 You can update your contact information, change your badge name, or upgrade your registration level by having your account holder login to their account.


### PR DESCRIPTION
Attendees are reporting that their confirmation email does not have a space between the last character of the reg code and the word 'and' that follows it. This is supported by a screenshot. This is intended to resolve that.