### PR TITLE
Remove duplicate print fields

### DIFF
--- a/mff_rams_plugin/templates/baseextra.html
+++ b/mff_rams_plugin/templates/baseextra.html
@@ -8,18 +8,6 @@
     </script>
 {% endif %}
 
-{% if c.PAGE_PATH == '/registration/form' %}
-    <script type="text/javascript">
-        $(function () {
-            $('#reprint_fee').insertAfter($.field('badge_status').parents('.form-group'));
-        });
-    </script>
-
-    <div id="reprint_fee" class="form-group">
-    {% include "badge_printing/reprint_fee.html" %}
-    </div>
-{% endif %}
-
 <script type="text/javascript">
     $(function() {
         {% if '/groups/' not in c.PAGE_PATH and '/group_admin/' not in c.PAGE_PATH %}

--- a/mff_rams_plugin/templates/regextra.html
+++ b/mff_rams_plugin/templates/regextra.html
@@ -1,21 +1,5 @@
 {%- import 'macros.html' as macros -%}
 {% if c.PAGE_PATH == '/registration/form' %}
-    {% if attendee.times_printed < 1 or attendee.print_pending %}
-        <script type="text/javascript">
-            $(function () {
-                $('#print_pending').insertAfter($.field('badge_status').parents('.form-group'));
-            });
-        </script>
-
-        <div id="print_pending" class="form-group">
-            <label for="print_pending" class="col-sm-3 control-label">Ready to Print</label>
-            <div class="col-sm-6 form-control-static">
-                {{ attendee.print_pending|yesno }}
-            </div>
-        </div>
-    {% endif %}
-
-
     <script type="text/javascript">
         $(function () {
             var showOrHideCompedReason = function() {


### PR DESCRIPTION
Once we merge https://github.com/MidwestFurryFandom/rams/pull/475, the reprint fee field will be shown properly along with everything else, so we don't need to force it to display in this plugin anymore.