### PR TITLE
Let approved dealers update their tax ID

### DIFF
--- a/mff_rams_plugin/model_checks.py
+++ b/mff_rams_plugin/model_checks.py
@@ -66,6 +66,7 @@ def badge_printed_name(attendee):
     if not attendee.badge_printed_name:
         return 'Please enter a name for your custom-printed badge.'
 
+
 @validation.Attendee
 def not_in_range(attendee):
     # Staff always keep their badge number regardless of their badge type.
@@ -76,6 +77,7 @@ def not_in_range(attendee):
                                                                                         c.BADGES[attendee.badge_type_real], 
                                                                                         lower_bound, 
                                                                                         upper_bound)
+
 
 @prereg_validation.Group
 def dealer_wares(group):
@@ -95,10 +97,28 @@ def power_usage(group):
         return 'Please provide a list of what powered devices you ' \
                'expect to use.'
 
+
 @prereg_validation.Group
 def ibt_num(group):
     if group.is_dealer and group.tax_number and not re.match("^[0-9-]*$", group.tax_number):
         return 'Please use only numbers and hyphens for your IBT number.'
+
+
+@prereg_validation.Group
+def dealer_categories(group):
+    if group.is_dealer and not group.categories:
+        if group.status == c.APPROVED:
+            # Categories are read-only for approved dealers, which erroneously unsets them
+            # I am 1000% going to regret this
+            group.categories = group.orig_value_of('categories')
+        else:
+            return "Please select at least one category your wares fall under."
+
+
+@prereg_validation.Group
+def edit_only_correct_statuses(group):
+    if group.status not in [c.APPROVED, c.WAITLISTED, c.UNAPPROVED]:
+        return "You cannot change your {} after it has been {}.".format(c.DEALER_APP_TERM, group.status_label)
 
 
 @prereg_validation.Group
@@ -123,8 +143,6 @@ def no_edit_post_approval(group):
             no_change.append('region')
         if group.orig_value_of('zip_code') != group.zip_code:
             no_change.append('postal code')
-        if group.orig_value_of('tax_number') != group.tax_number:
-            no_change.append('IBT number')
 
         if no_change:
             return "You cannot change the following information after your application has been approved: {}.".format(', '.join(no_change))

--- a/mff_rams_plugin/templates/groupextra.html
+++ b/mff_rams_plugin/templates/groupextra.html
@@ -79,7 +79,7 @@
 <div class="form-group">
     <label for="power_usage" class="col-sm-3 control-label">Power Usage</label>
     <div class="col-sm-6">
-        <textarea class="form-control" name="power_usage" id="power_usage" placeholder="Please provide a listing of what devices you will be using." rows="4">{{ group.power_usage }}</textarea>
+        <textarea{% if page_ro %} readonly{% endif %} class="form-control" name="power_usage" id="power_usage" placeholder="Please provide a listing of what devices you will be using." rows="4">{{ group.power_usage }}</textarea>
     </div>
 </div>
 {% if not c.PAGE_PATH == '/group_admin/form' and (group and group.power or attendee and attendee.badge_type == c.PSEUDO_DEALER_BADGE) %}
@@ -94,6 +94,9 @@
     </div>
 </div>
 </div>
+{% if group.status == c.APPROVED %}
+    <button type="submit" class="btn btn-primary" value="Update Application">Update Application</button>
+{% endif %}
 {% endif %}
 
 {% if c.PAGE_PATH == '/group_admin/form' and group.is_dealer or new_dealer %}


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/rams/issues/465. This is trickier than it looks, as we can't override the page handler that processes this form and it assumes that all fields are editable.