### PR TITLE
[WIP] Post con prereg banner

### DIFF
--- a/mff_rams_plugin/templates/landing/index.html
+++ b/mff_rams_plugin/templates/landing/index.html
@@ -118,7 +118,7 @@
                     {% if c.POST_CON %}
                       <div class="col-sm-6 col-sm-offset-3 alert alert-warning"> 
                         We hope you enjoyed {{ c.EVENT_NAME_AND_YEAR }}! 
-                        We look forward to seeing you {% if c.EVENT_YEAR %}} in {{ c.EVENT_YEAR|add:"1" }}! {% else %} next year! {% endif %}
+                        We look forward to seeing you {% if c.EVENT_YEAR %} in {{ c.EVENT_YEAR|int +1 }}! {% else %} next year! {% endif %}
                         Watch our website (<a href="https://www.furfest.org">https://www.furfest.org</a>) and our Twitter (<a href="https://twitter.com/Furfest">@Furfest</a>) for announcements.
                       </div>
                     {% else %}

--- a/mff_rams_plugin/templates/landing/index.html
+++ b/mff_rams_plugin/templates/landing/index.html
@@ -114,9 +114,19 @@
             <div class="row-fluid">
                 <div class="col-xs-12">
                     <h1 class="text-center">{{ c.EVENT_NAME_AND_YEAR }} Registration<br><br></h1>
-                    <div class="col-sm-6 col-sm-offset-3 alert alert-warning">Please refer to our <a href="https://www.furfest.org/covid-19" target="_blank">Covid-19 Policy</a> 
+
+                    {% if c.POST_CON %}
+                      <div class="col-sm-6 col-sm-offset-3 alert alert-warning"> 
+                        We hope you enjoyed {{ c.EVENT_NAME_AND_YEAR }}! 
+                        We look forward to seeing you {% if c.EVENT_YEAR %}} in {{ c.EVENT_YEAR|add:"1" }}! {% else %} next year! {% endif %}
+                        Watch our website (<a href="https://www.furfest.org">https://www.furfest.org</a>) and our Twitter (<a href="https://twitter.com/Furfest">@Furfest</a>) for announcements.
+                      </div>
+                    {% else %}
+                      <div class="col-sm-6 col-sm-offset-3 alert alert-warning">Please refer to our <a href="https://www.furfest.org/covid-19" target="_blank">Covid-19 Policy</a> 
                         for information regarding current attendee requirements for FurFest 2021. Non-compliance of the Covid-19 
                         policy will result in badge rescindment.</div>
+                    {% endif %}
+
                     {% if kiosk_mode %}
                     <div class="text-center">
                         <a class="btn btn-success btn-xl" href="../preregistration/form" role="button">Register for {{ c.EVENT_NAME_AND_YEAR }}</a>

--- a/mff_rams_plugin/templates/landing/index.html
+++ b/mff_rams_plugin/templates/landing/index.html
@@ -143,8 +143,11 @@
                     </div>
                         {% include 'preregistration/login.html' %}
                     {% endif %}
+                      {% if not c.POST_CON %}
                         <br><h2 class="text-center">or</h2><br/>
+                      {% endif %}
                     {% endif %}
+                    {% if not c.POST_CON %}
                     <div class="text-center">
                         <div class="btn-group">
                         <a class="btn btn-primary btn-lg" href="../preregistration/form" role="button">
@@ -158,6 +161,7 @@
                         </div>
                         <br><br>
                     </div>
+                    {% endif %}
                     {% endif %}
                     {% if kiosk_mode %}
                     <p class="text-right">


### PR DESCRIPTION
Works but a little ugly. 

* After-con, swapped out the COVID banner for "see you next year" banner
* After-con, hides the create account button & the "OR".

Currently has some layout issues. But maybe we don't care because we really should brand this for next year (next year for sure).

<img width="1202" alt="image" src="https://user-images.githubusercontent.com/910490/144934500-424fb9ad-5902-4593-8fa4-4dcc8e7da487.png">
