### PR TITLE
Improve power options

### DIFF
--- a/mff_rams_plugin/config.py
+++ b/mff_rams_plugin/config.py
@@ -49,7 +49,12 @@ class ExtraConfig:
 
     @property
     def DEALER_POWER_OPTS(self):
-        return [(int(v), k) for k, v in config['integer_enums']['dealer_power'].items()]
+        power_opts = []
+        for count, desc in sorted(c.DEALER_POWERS.items()):
+            price_info = ": ${}".format(c.POWER_PRICES[count])\
+                if c.POWER_PRICES.get(count) else ""
+            power_opts.append((count, 'Tier {}{} {}'.format(count, price_info, desc)))
+        return power_opts
 
     @request_cached_property
     @dynamic

--- a/mff_rams_plugin/configspec.ini
+++ b/mff_rams_plugin/configspec.ini
@@ -7,20 +7,12 @@ dealer_payment_days = integer(default=14)
 # Dealers have the option to request a power drop at their table.
 [power_prices]
 0 = integer(default=0)
-1 = integer(default=40)
-2 = integer(default=40)
-3 = integer(default=40)
-4 = integer(default=40)
 
 [integer_enums]
 no_power = integer(default=0)
 
 [[dealer_power]]
 "No power" = integer(default=0)
-"Level 1 (up to 300W)" = integer(default=1)
-"Level 2 (301-600W)" = integer(default=2)
-"Level 3 (601-1000W)" = integer(default=3)
-"Level 4 (Custom, please contact us to arrange details.)" = integer(default=4)
 
 [enums]
 [[fursuiting]]

--- a/mff_rams_plugin/model_checks.py
+++ b/mff_rams_plugin/model_checks.py
@@ -92,6 +92,12 @@ def dealer_description(group):
 
 
 @prereg_validation.Group
+def selected_power(group):
+    if not group.power and group.power != 0:
+        return 'Please select what power level you want, or no power.'
+
+
+@prereg_validation.Group
 def power_usage(group):
     if group.power and not group.power_usage:
         return 'Please provide a list of what powered devices you ' \

--- a/mff_rams_plugin/templates/groupextra.html
+++ b/mff_rams_plugin/templates/groupextra.html
@@ -58,10 +58,12 @@
 <div id="power-fields">
 <div class="form-group">
     <label for="power_level" class="col-sm-3 control-label">Power Level</label>
-    {% call macros.read_only_if(page_ro, c.DEALER_POWER_OPTS[group.power][1], check_dealer_editable=(group, 'power')) %}
+    {% call macros.read_only_if(page_ro, c.DEALER_POWER_OPTS[group.power or 0][1], check_dealer_editable=(group, 'power')) %}
     <div class="col-sm-6">
         <select name="power" id="power" class="form-control">
-            {{ options(c.DEALER_POWER_OPTS, group.power) }}
+            <option value=""{% if new_dealer or attendee and attendee.badge_type == c.PSEUDO_DEALER_BADGE %} selected="selected"{% endif %}>Select a Power Level</option>
+            <option value="0">No power</option>
+            {{ options(c.DEALER_POWER_OPTS[1:], None if new_dealer or attendee and attendee.badge_type == c.PSEUDO_DEALER_BADGE else group.power) }}
         </select>
     </div>
     {% endcall %}


### PR DESCRIPTION
Power options now show their price (if one is configured), and there is also a default 'select a power level' option so dealers actually look at the power field.