### PR TITLE
Update dealer emails and costs

### DIFF
--- a/mff_rams_plugin/__init__.py
+++ b/mff_rams_plugin/__init__.py
@@ -6,6 +6,7 @@ from .config import config
 from . import models  # noqa: F401
 from . import model_checks  # noqa: F401
 from . import automated_emails  # noqa: F401
+from . import receipt_items  # noqa: F401
 
 
 static_overrides(join(config['module_root'], 'static'))

--- a/mff_rams_plugin/receipt_items.py
+++ b/mff_rams_plugin/receipt_items.py
@@ -17,7 +17,7 @@ def table_cost(group):
 
 @cost_calculation.Group
 def power_cost(group):
-    if group.power_fee:
-        return ("Custom Fee for Tier {} Power".format(group.power), group.power_fee)
-    elif group.auto_recalc and group.default_power_cost:
-        return ("Tier {} Power Fee".format(group.power), group.default_power_cost)
+    if group.auto_recalc and group.default_power_cost:
+        return ("Tier {} Power Fee".format(group.power), int(group.default_power_cost) * 100)
+    elif group.power_fee:
+        return ("Custom Fee for Tier {} Power".format(group.power), group.power_fee * 100)

--- a/mff_rams_plugin/templates/emails/dealers/application.html
+++ b/mff_rams_plugin/templates/emails/dealers/application.html
@@ -5,12 +5,11 @@
 ({{ group.name }}) has successfully submitted a Dealer application for {{ c.EVENT_NAME }}
 this coming {{ event_dates() }}. Below is a copy of your application. You may
 <a href="{{ c.URL_BASE }}/preregistration/group_members?id={{ group.id }}">update it here</a> or
-<a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ group.leader.id }}">view your badge here</a>{% if c.ATTENDEE_ACCOUNTS_ENABLED %}
-after logging into your account{% endif %}.
+<a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ group.leader.id }}">view your badge here</a>{% if c.ATTENDEE_ACCOUNTS_ENABLED %} after logging into your account{% endif %}.
 <ul>
     <li><strong>Dealer Table Name</strong>: {{ group.name }}</li>
-    <li><strong>Tables</strong>: {{ group.tables_repr }} ({{ c.TABLE_PRICES[group.tables]|format_currency }}) </li>
-    <li><strong>Badges</strong>: {{ group.badges }} badge{{ group.badges|pluralize }} ({{ (group.new_badge_cost * group.badges)|format_currency }}) </li>
+    <li><strong>Tables</strong>: {{ group.tables_repr }} ({{ group.default_table_cost|format_currency }}) </li>
+    <li><strong>Badges</strong>: {{ group.badges }} badge{{ group.badges|pluralize }} ({{ group.default_badge_cost|format_currency }}) </li>
     {% if group.power %}
     <li><strong>Power</strong>: {{ c.PREREG_DEALER_POWER_OPTS[group.power][1] }}
     {% endif %}

--- a/mff_rams_plugin/templates/emails/dealers/approved.html
+++ b/mff_rams_plugin/templates/emails/dealers/approved.html
@@ -16,8 +16,8 @@ Payment is expected by: {{ group.dealer_payment_due|datetime_local }} or your ap
 <p>
 This registration includes:
 <ul>
-    <li> {{ group.tables_repr }} ({{ group.table_cost|format_currency }}) </li>
-    <li> {{ group.badges }} badge{{ group.badges|pluralize }} ({{ group.badge_cost|format_currency }}) </li>
+    <li> {{ group.tables_repr }} ({{ group.default_table_cost|format_currency }}) </li>
+    <li> {{ group.badges }} badge{{ group.badges|pluralize }} ({{ group.default_badge_cost|format_currency }}) </li>
     <li> 
         {% if group.power > 0 %}
         Tier {{ group.power }} power ({{ c.DEALER_POWER_OPTS[group.power][1] if group.default_power_cost else "custom" }})
@@ -33,7 +33,7 @@ This registration includes:
 <li>No selling out of a hotel room, away from the dealer area, or away from your table.</li>
 <li>A list of confirmed dealers will be posted to the web site and will be included in our ConBook. This listing will include your business name and the description of your merchandise from your application, along with a link to your website if one was listed on your dealer application. Dealers are encouraged to check their listing on the web site and promptly request any changes or corrections.</li>
 <li>Advertising space is available in our convention book. If you are interested in purchasing an ad please contact {{ c.PUBLICATIONS_EMAIL }}.</li>
-<li>You are required to collect Illinois sales tax at MFF. You are not required to have an Illinois business license, but if you wish to obtain one you may do so at {{ c.BUSINESS_LICENSE_URL }} . MFF will be providing sales tax reporting forms at the con to those dealers who do not have an Illinois business license. We are required to provide a list of our dealers to IDOR, but we will not be collecting tax payments from our dealers.</li>
+<li>You are required to collect Illinois sales tax at MFF. You are not required to have an Illinois business license, but if you wish to obtain one you may do so at {{ c.BUSINESS_LICENSE_URL }} . MFF will be providing sales tax reporting forms to those dealers who do not have an Illinois business license. We are required to provide a list of our dealers to IDOR, but we will not be collecting tax payments from our dealers.</li>
 <li>An email will be sent to all dealers about two weeks before Midwest Furfest with details on parking and unloading access and any other information you may need before arriving.</li>
 <li>Any questions regarding Dealers Den operations should be directed to {{ c.MARKETPLACE_EMAIL }}</li>
 <li>If for any reason you are unable to deal at Midwest FurFest, please notify us promptly. Full refunds can be made if we receive your cancellation prior to {{ c.DEALER_REG_SHUTDOWN|datetime_local }}. After that date, refunds are possible only if we are able to resell your space.


### PR DESCRIPTION
Fixes a bug where this plugin's receipt items weren't being included. Also fixes the emails for dealers and removes 'at the con' text from the approval email. Depends on https://github.com/MidwestFurryFandom/rams/pull/577.