### PR TITLE
Swapped covid policy link text to name & year

### DIFF
--- a/mff_rams_plugin/templates/landing/index.html
+++ b/mff_rams_plugin/templates/landing/index.html
@@ -115,7 +115,7 @@
                 <div class="col-xs-12">
                     <h1 class="text-center">{{ c.EVENT_NAME_AND_YEAR }} Registration<br><br></h1>
                     <div class="col-sm-6 col-sm-offset-3 alert alert-warning">Please refer to our <a href="https://www.furfest.org/covid-19" target="_blank">Covid-19 Policy</a> 
-                        for information regarding current attendee requirements for FurFest 2021. Non-compliance of the Covid-19 
+                        for information regarding current attendee requirements for {{ c.EVENT_NAME_AND_YEAR }}. Non-compliance of the Covid-19 
                         policy will result in badge rescindment.</div>
                     {% if kiosk_mode %}
                     <div class="text-center">


### PR DESCRIPTION
Was hard-coded for ??? reasons. Now not, since we need this again for 2022.