### PR TITLE
Stop requiring under-12 badge

### DIFF
--- a/mff_rams_plugin/config.py
+++ b/mff_rams_plugin/config.py
@@ -67,6 +67,17 @@ class ExtraConfig:
     def SHINY_BADGE_COUNT(self):
         return self.get_badge_count_by_type(c.SHINY_BADGE)
 
+    @property
+    def PREREG_BADGE_TYPES(self):
+        types = [self.ATTENDEE_BADGE, self.PSEUDO_DEALER_BADGE]
+        for reg_open, badge_type in [(self.BEFORE_GROUP_PREREG_TAKEDOWN, self.PSEUDO_GROUP_BADGE)]:
+            if reg_open:
+                types.append(badge_type)
+        for badge_type in self.BADGE_TYPE_PRICES:
+            if badge_type not in types:
+                types.append(badge_type)
+        return types
+
     @request_cached_property
     @dynamic
     def AT_THE_DOOR_BADGE_OPTS(self):

--- a/mff_rams_plugin/model_checks.py
+++ b/mff_rams_plugin/model_checks.py
@@ -25,15 +25,6 @@ def need_comped_reason(attendee):
 
 
 @validation.Attendee
-def allowed_to_register(attendee):
-    if not attendee.age_group_conf['can_register']:
-        # It's COVID time!
-        return 'At this time, attendees under the age of 12 are unable to receive Covid-19 vaccinations \
-        and cannot attend FurFest 2021. We hope to see you back in 2022. Please email registration@furfest.org \
-        if you have any questions.'
-
-
-@validation.Attendee
 @validation.Group
 def no_emojis(model):
     for column in model.__table__.columns:

--- a/mff_rams_plugin/models.py
+++ b/mff_rams_plugin/models.py
@@ -142,10 +142,11 @@ class Attendee:
             return "Could not undo extras, this attendee has an open receipt!"
         self.amount_extra = 0
         self.extra_donation = 0
-        if c.STAFF_RIBBON in self.ribbon_ints:
-            self.badge_type = c.STAFF_BADGE
-        else:
-            self.badge_type = c.ATTENDEE_BADGE
+        if self.badge_type in c.BADGE_TYPE_PRICES:
+            if c.STAFF_RIBBON in self.ribbon_ints:
+                self.badge_type = c.STAFF_BADGE
+            else:
+                self.badge_type = c.ATTENDEE_BADGE
 
     def calculate_badge_cost(self, use_promo_code=False):
         registered = self.registered_local if self.registered else None


### PR DESCRIPTION
Apparently I hardcoded the "Child Badge" type at some point. This removes it for MFF. Also includes a very minor fix for undo_extras.