### PR TITLE
Update MFF dealer emails with default costs

### DIFF
--- a/mff_rams_plugin/model_checks.py
+++ b/mff_rams_plugin/model_checks.py
@@ -120,5 +120,5 @@ def edit_only_correct_statuses(group):
 
 @validation.Group
 def no_approval_without_power_fee(group):
-    if group.status == c.APPROVED and group.auto_recalc and not group.power_fee and group.default_power_cost == None:
+    if group.status == c.APPROVED and group.auto_recalc and not group.power_fee and group.default_power_fee == None:
         return "Please set a power fee. To provide free power, turn off automatic recalculation."

--- a/mff_rams_plugin/models.py
+++ b/mff_rams_plugin/models.py
@@ -46,7 +46,7 @@ class Group:
     @presave_adjustment
     def set_power_fee(self):
         if self.auto_recalc:
-            self.power_fee = self.default_power_cost or self.power_fee
+            self.power_fee = self.default_power_fee or self.power_fee
 
         if self.power_fee == None:
             self.power_fee = 0
@@ -57,7 +57,7 @@ class Group:
         self.tables = int(self.tables)
 
     @property
-    def default_power_cost(self):
+    def default_power_fee(self):
         return c.POWER_PRICES.get(int(self.power), None)
 
     @property

--- a/mff_rams_plugin/receipt_items.py
+++ b/mff_rams_plugin/receipt_items.py
@@ -11,13 +11,13 @@ def table_cost(group):
     if not table_count:
         return
     if group.table_fee:
-        return ("Custom Fee for {}".format(group.tables_repr), group.table_fee)
+        return ("Custom Fee for {}".format(group.tables_repr), group.table_fee * 100)
     
     return ("{} Fee".format(group.tables_repr), c.TABLE_PRICES.get(table_count) * 100)
 
 @cost_calculation.Group
 def power_cost(group):
-    if group.auto_recalc and group.default_power_cost:
-        return ("Tier {} Power Fee".format(group.power), int(group.default_power_cost) * 100)
+    if group.auto_recalc and group.default_power_fee:
+        return ("Tier {} Power Fee".format(group.power), int(group.default_power_fee) * 100)
     elif group.power_fee:
         return ("Custom Fee for Tier {} Power".format(group.power), group.power_fee * 100)

--- a/mff_rams_plugin/templates/emails/dealers/application.html
+++ b/mff_rams_plugin/templates/emails/dealers/application.html
@@ -13,7 +13,7 @@ this coming {{ event_dates() }}. Below is a copy of your application. You may
     {% if group.power %}
     <li><strong>Power</strong>: {{ c.PREREG_DEALER_POWER_OPTS[group.power][1] }}
     {% endif %}
-    <li><strong>Total Price</strong>: {{ group.cost|format_currency }}{% if not group.default_power_cost %} plus custom power fee{% endif %}</li>
+    <li><strong>Total Price</strong>: {{ group.cost|format_currency }}{% if not group.default_power_fee %} plus custom power fee{% endif %}</li>
     <li><strong>Description</strong>: {{ group.description }}</li>
     {% if group.special_needs %}<li><strong>Table Requests and Special Requests</strong>: {{ group.special_needs }}</li>{% endif %}
     <li><strong>Website URL</strong>: {{ group.website }}</li>

--- a/mff_rams_plugin/templates/emails/dealers/approved.html
+++ b/mff_rams_plugin/templates/emails/dealers/approved.html
@@ -20,7 +20,7 @@ This registration includes:
     <li> {{ group.badges }} badge{{ group.badges|pluralize }} ({{ group.default_badge_cost|format_currency }}) </li>
     <li> 
         {% if group.power > 0 %}
-        Tier {{ group.power }} power ({{ c.DEALER_POWER_OPTS[group.power][1] if group.default_power_cost else "custom" }})
+        Tier {{ group.power }} power ({{ c.DEALER_POWER_OPTS[group.power][1] if group.default_power_fee else "custom" }})
         for {{ group.power_fee|format_currency }} 
         {% else %}No power {% endif %}
     </li>

--- a/mff_rams_plugin/templates/groupextra.html
+++ b/mff_rams_plugin/templates/groupextra.html
@@ -112,7 +112,7 @@
 
 {% if c.PAGE_PATH == '/preregistration/group_members' and group.status == c.APPROVED and group.power_fee %}
 <li id="power_cost">
-    {{ group.power_fee|format_currency }} for tier {{ group.power }} power ({{ c.DEALER_POWER_OPTS[group.power][1] if group.default_power_cost else "custom" }})
+    {{ group.power_fee|format_currency }} for tier {{ group.power }} power ({{ c.DEALER_POWER_OPTS[group.power][1] if group.default_power_fee else "custom" }})
 </li>
 
 <script type="text/javascript">
@@ -144,7 +144,7 @@
     <div class="col-sm-6">
         <div class="input-group">
         <span class="input-group-addon">$</span>
-        <input type="number" name="power_fee" value="{{ group.power_fee }}" placeholder="{{ group.default_power_cost|default('Please set a power fee.', true) }}" class="form-control" />
+        <input type="number" name="power_fee" value="{{ group.power_fee }}" placeholder="{{ group.default_power_fee|default('Please set a power fee.', true) }}" class="form-control" />
         <span class="input-group-addon">.00</span>
         </div>
     </div>


### PR DESCRIPTION
Fixes the MFF version of the dealer approval email to use the recently-added default_ cost property. Also removes a collision between a named custom property and the default_ cost property.