### PR TITLE
Remove DEALER_BADGE_PRICE override

### DIFF
--- a/mff_rams_plugin/config.py
+++ b/mff_rams_plugin/config.py
@@ -21,10 +21,6 @@ c.MENU.append_menu_item(
 @Config.mixin
 class ExtraConfig:
     @property
-    def DEALER_BADGE_PRICE(self):
-        return self.get_attendee_price()
-
-    @property
     def TABLE_OPTS(self):
         return [(1, 'Single Table'),
                 (2, 'Double Table'),


### PR DESCRIPTION
This override doesn't really work when you have price bumps, so we're going to actually set it in config instead.