### PR TITLE
Don't add power to custom cost

### DIFF
--- a/mff_rams_plugin/receipt_items.py
+++ b/mff_rams_plugin/receipt_items.py
@@ -17,10 +17,10 @@ def table_cost(group):
 
 @cost_calculation.Group
 def power_cost(group):
-    power_fee = 0 if not group.power_fee else int(group.power_fee)
-    default_power_fee = 0 if not group.default_power_fee else int(group.default_power_fee)
+    if not group.auto_recalc:
+        return None
 
-    if (group.auto_recalc and group.default_power_fee) or power_fee == default_power_fee:
+    if group.default_power_fee:
         return ("Tier {} Power Fee".format(group.power), int(group.default_power_fee) * 100)
     elif group.power_fee:
         return ("Custom Fee for Tier {} Power".format(group.power), group.power_fee * 100)

--- a/mff_rams_plugin/templates/groupextra.html
+++ b/mff_rams_plugin/templates/groupextra.html
@@ -110,7 +110,7 @@
 </div>
 {% endif %}
 
-{% if c.PAGE_PATH == '/preregistration/group_members' and group.status == c.APPROVED and group.power_fee %}
+{% if c.PAGE_PATH == '/preregistration/group_members' and group.status == c.APPROVED and group.power_fee and group.auto_recalc %}
 <li id="power_cost">
     {{ group.power_fee|format_currency }} for tier {{ group.power }} power ({{ c.DEALER_POWER_OPTS[group.power][1] if group.default_power_fee else "custom" }})
 </li>


### PR DESCRIPTION
Turns out we don't want the power fee added on top of the custom cost, which makes sense now that I realize the custom power fee does not require auto_recalc to be turned off