### PR TITLE
Actually use the configured consent form URL

### DIFF
--- a/mff_rams_plugin/templates/emails/reg_workflow/under_18_reminder.txt
+++ b/mff_rams_plugin/templates/emails/reg_workflow/under_18_reminder.txt
@@ -6,7 +6,7 @@ All attendees 17 years old during the convention must either attend with their p
 
 All attendees age 16 and under during the convention must attend with their parent/guardian OR with another adult approved by the parent/guardian. If you are attending with another adult approved by your parent or guardian, the Short Term Guardian Form must be completed and notorized.
 
-Information on completing the Parental Permission Form or the Short Term Guardian Form can be found here: https://www.furfest.org/minor-consent-form
+Information on completing the Parental Permission Form or the Short Term Guardian Form can be found here: {{ c.CONSENT_FORM_URL }}
 
 If you are actually over 18, please update your age in our database at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} prior to picking up your badge.
 


### PR DESCRIPTION
... whoops.