### PR TITLE
Fix cost_changes additions

### DIFF
--- a/mff_rams_plugin/receipt_items.py
+++ b/mff_rams_plugin/receipt_items.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 from uber.config import c
 from uber.decorators import cost_calculation, credit_calculation
-from uber.models import Group
+from uber.receipt_items import Group
 
 Group.cost_changes['power'] = ('Power Level', "calc_group_price_change")
 Group.cost_changes['power_fee'] = ('Custom Power Fee', "calc_group_price_change")


### PR DESCRIPTION
I just found this while adding cost_changes to MAGFest -- the server was throwing an error about the cost_changes property not existing. I have no idea if this ever worked for MFF, but if it didn't, it apparently would have failed silently.