### PR TITLE
Enable adding existing badges for dealers

### DIFF
--- a/mff_rams_plugin/models.py
+++ b/mff_rams_plugin/models.py
@@ -112,6 +112,11 @@ class Group:
     def dealer_max_badges(self):
         return c.MAX_DEALERS or min(math.ceil(self.tables) * 3, 12)
 
+    @property
+    def can_add_existing_badges(self):
+        if self.is_dealer:
+            return True
+
 
 @Session.model_mixin
 class ArtistMarketplaceApplication:


### PR DESCRIPTION
Enables https://github.com/MidwestFurryFandom/rams/pull/694 for dealers.