### PR TITLE
Presell one-day badges during prereg

### DIFF
--- a/mff_rams_plugin/configspec.ini
+++ b/mff_rams_plugin/configspec.ini
@@ -24,6 +24,10 @@ no_power = integer(default=0)
 "No power" = integer(default=0)
 
 [enums]
+[[attendance_type]]
+single_day = string(default="One-Day Badge")
+weekend = string(default="Full Weekend Badge")
+
 [[accessibility_service]]
 asl = string(default="I need an ASL interpreter")
 mobility_device = string(default="I use a wheelchair or other mobility device")

--- a/mff_rams_plugin/forms.py
+++ b/mff_rams_plugin/forms.py
@@ -84,7 +84,10 @@ class PreregOtherInfo:
 
 @MagForm.form_mixin
 class BadgeExtras:
+    field_aliases = {'badge_type': ['badge_type_single']}
     new_or_changed_validation = CustomValidation()
+    attendance_type = HiddenIntField('Single Day or Weekend Badge?')
+    badge_type_single = HiddenIntField('Badge Type')
 
     @new_or_changed_validation.badge_type
     def badge_upgrade_sold_out(form, field):
@@ -94,6 +97,9 @@ class BadgeExtras:
             raise ValidationError("Shiny Sponsor badges have sold out.")
 
     def badge_type_desc(self):
+        return Markup('<span class="popup"><a href="https://www.furfest.org/registration" target="_blank"><i class="fa fa-question-circle" aria-hidden="true"></i> Badge details, pickup information, and refund policy</a></span>')
+    
+    def badge_type_single_desc(self):
         return Markup('<span class="popup"><a href="https://www.furfest.org/registration" target="_blank"><i class="fa fa-question-circle" aria-hidden="true"></i> Badge details, pickup information, and refund policy</a></span>')
 
 

--- a/mff_rams_plugin/forms.py
+++ b/mff_rams_plugin/forms.py
@@ -78,8 +78,18 @@ class OtherInfo:
 class PreregOtherInfo:
     group_name = TableInfo.name
 
-    def name_label(self):
+    def group_name_label(self):
         return "Table Name"
+    
+    def get_optional_fields(self, attendee, is_admin=False):
+        optional_list = []
+        if not self.requested_accessibility_services.data:
+            optional_list.append('accessibility_requests')
+
+        if not attendee.is_dealer:
+            optional_list.append('group_name')
+
+        return optional_list
 
 
 @MagForm.form_mixin

--- a/mff_rams_plugin/models.py
+++ b/mff_rams_plugin/models.py
@@ -165,6 +165,22 @@ class Attendee:
             if not self.is_new:
                 update_receipt(self.id, {'paid': c.NEED_NOT_PAY})
 
+    @property
+    def attendance_type(self):
+        return c.SINGLE_DAY if self.badge_type in [c.ONE_DAY_BADGE, c.FRIDAY, c.SATURDAY, c.SUNDAY] else c.WEEKEND
+    
+    @property
+    def available_single_badge_opts(self):
+        # You can't switch between single-day badges, so this is all or nothing
+        if self.is_new or self.is_unpaid:
+            return c.FORMATTED_SINGLE_BADGES
+
+        return [{
+            'name': self.badge_type_label,
+            'desc': 'Can be upgraded to an Attendee badge later.',
+            'value': self.badge_type
+            }]
+
     def calculate_badge_cost(self, use_promo_code=False, include_price_override=True):
         # Adds overrides for a couple special cases where a badge should be free
         if self.paid == c.NEED_NOT_PAY or self.badge_status == c.NOT_ATTENDING or self.badge_type == c.PARENT_IN_TOW_BADGE:

--- a/mff_rams_plugin/templates/forms/attendee/badge_extras.html
+++ b/mff_rams_plugin/templates/forms/attendee/badge_extras.html
@@ -1,5 +1,35 @@
 {% extends "uber/templates/forms/attendee/badge_extras.html" %}
 
+{% block badge_type %}
+{{ badge_extras.attendance_type(id=id_upgrade_prepend ~ "attendance_type") }}
+
+{% if c.PRESELL_ONE_DAYS and (not receipt or upgrade_modal and attendee.attendance_type == c.SINGLE_DAY) %}
+    <div class="row g-sm-3">
+    {{ form_macros.card_select(badge_extras.attendance_type,
+                                c.FORMATTED_ATTENDANCE_TYPES,
+                                target_field_id=id_upgrade_prepend ~ "attendance_type") }}
+    </div>
+    <div class="row g-sm-3">
+        {{ form_macros.card_select(badge_extras.badge_type_single,
+                                    attendee.available_single_badge_opts, disabled_opts=c.SOLD_OUT_BADGES_SINGLE[1:] if attendee.badge_type in c.SOLD_OUT_BADGES_SINGLE else c.SOLD_OUT_BADGES_SINGLE,
+                                    target_field_id=id_upgrade_prepend ~ "badge_type") }}
+    </div>
+    <script type="text/javascript">
+        var switchBadgeTypeOpts = function() {
+            let attendanceType = $('#{{ id_upgrade_prepend }}attendance_type').val();
+            setVisible($('#badge_type_single-select').parents('.row'), attendanceType == '{{ c.SINGLE_DAY }}');
+            setVisible($('#badge_type-select').parents('.row'), attendanceType == '{{ c.WEEKEND }}');
+        }
+        $(function () {
+            switchBadgeTypeOpts();
+            $('#{{ id_upgrade_prepend }}attendance_type').on('change', switchBadgeTypeOpts);
+        })
+    </script>
+{% endif %}
+
+{{ super() }}
+{% endblock %}
+
 {% block add_ons %}{% endblock %}
 
 {% block perk_info %}


### PR DESCRIPTION
Adds the ability to select either a one-day badge or a weekend badge, which swaps between two sets of badge options. Attendees can upgrade from any one-day badge to any weekend badge, and the one-day/weekend option is hidden if the attendee already has a weekend badge.

Also fixes a bug introduced when adding the group name check for attendees by making the group name field on the third page optional for non-dealers.