### PR TITLE
Updates for hotel lottery changes

### DIFF
--- a/mff_rams_plugin/models.py
+++ b/mff_rams_plugin/models.py
@@ -27,13 +27,6 @@ class SessionMixin:
 
 
 @Session.model_mixin
-class LotteryApplication:
-    @property
-    def qualifies_for_staff_lottery(self):
-        return self.attendee.badge_type == c.STAFF_BADGE or c.STAFF_RIBBON in self.attendee.ribbon_ints
-
-
-@Session.model_mixin
 class Group:
     power = Column(Choice(c.DEALER_POWER_OPTS), default=-1)
     power_fee = Column(Integer, default=0)
@@ -386,6 +379,10 @@ class Attendee:
     @property
     def has_personalized_badge(self):
         return True
+
+    @property
+    def staff_hotel_lottery_eligible(self):
+        return self.badge_type == c.STAFF_BADGE or c.STAFF_RIBBON in self.ribbon_ints
 
 
 @Session.model_mixin

--- a/mff_rams_plugin/templates/hotel_lottery/lottery_tos.html
+++ b/mff_rams_plugin/templates/hotel_lottery/lottery_tos.html
@@ -1,4 +1,3 @@
-{% if 'index' not in c.PAGE_PATH %}<h2>How the Room Lottery Works</h2>{% endif %}
 <p>
     The {{ c.EVENT_NAME }} room lottery is open and applicable to all available room types at all {{ c.EVENT_NAME }} partner hotels, including suites, ADA rooms, and standard rooms.
     <strong>Initially, these rooms are only available through the lottery</strong>, and any unclaimed/cancelled rooms will be made available subsequently via booking links on <a href="http://furfest.org/" target="_blank">furfest.org</a> as they become available.


### PR DESCRIPTION
Removes a duplicate header and reflects a change in the main repo where we moved the staff lottery check to the Attendee class.