### PR TITLE
Add validation for single-day badges

### DIFF
--- a/mff_rams_plugin/forms.py
+++ b/mff_rams_plugin/forms.py
@@ -95,9 +95,9 @@ class PreregOtherInfo:
 @MagForm.form_mixin
 class BadgeExtras:
     field_aliases = {'badge_type': ['badge_type_single']}
-    new_or_changed_validation = CustomValidation()
+    field_validation, new_or_changed_validation = CustomValidation(), CustomValidation()
     attendance_type = HiddenIntField('Single Day or Weekend Badge?')
-    badge_type_single = HiddenIntField('Badge Type')
+    badge_type_single = HiddenIntField('Badge Type', default=c.ATTENDEE_BADGE)
 
     @new_or_changed_validation.badge_type
     def badge_upgrade_sold_out(form, field):
@@ -105,6 +105,11 @@ class BadgeExtras:
             raise ValidationError("Sponsor badges have sold out.")
         elif field.data == c.SHINY_BADGE and not c.SHINY_BADGE_AVAILABLE:
             raise ValidationError("Shiny Sponsor badges have sold out.")
+
+    @field_validation.badge_type_single
+    def must_select_day(form, field):
+        if form.attendance_type.data and form.attendance_type.data == c.SINGLE_DAY and field.data not in [c.FRIDAY, c.SATURDAY, c.SUNDAY]:
+            raise ValidationError("Please select which day you would like to attend.")
 
     def badge_type_desc(self):
         return Markup('<span class="popup"><a href="https://www.furfest.org/registration" target="_blank"><i class="fa fa-question-circle" aria-hidden="true"></i> Badge details, pickup information, and refund policy</a></span>')

--- a/mff_rams_plugin/templates/forms/attendee/badge_extras.html
+++ b/mff_rams_plugin/templates/forms/attendee/badge_extras.html
@@ -9,7 +9,11 @@
                                 c.FORMATTED_ATTENDANCE_TYPES,
                                 target_field_id=id_upgrade_prepend ~ "attendance_type") }}
     </div>
+    <div id="one-day-alert" class="row">
+        <div class="col"><div class="alert alert-info mb-0"><em>Please select which day you would like to attend.</em></div></div>
+    </div>
     <div class="row g-sm-3">
+        <input type="hidden" id="badge_type_single" /> {# Dummy attribute to make validation message hideable #}
         {{ form_macros.card_select(badge_extras.badge_type_single,
                                     attendee.available_single_badge_opts, disabled_opts=c.SOLD_OUT_BADGES_SINGLE[1:] if attendee.badge_type in c.SOLD_OUT_BADGES_SINGLE else c.SOLD_OUT_BADGES_SINGLE,
                                     target_field_id=id_upgrade_prepend ~ "badge_type") }}
@@ -18,6 +22,7 @@
         var switchBadgeTypeOpts = function() {
             let attendanceType = $('#{{ id_upgrade_prepend }}attendance_type').val();
             setVisible($('#badge_type_single-select').parents('.row'), attendanceType == '{{ c.SINGLE_DAY }}');
+            setVisible($('#one-day-alert'), attendanceType == '{{ c.SINGLE_DAY }}');
             setVisible($('#badge_type-select').parents('.row'), attendanceType == '{{ c.WEEKEND }}');
         }
         $(function () {


### PR DESCRIPTION
Adds a callout to select which day you want, and a validation for if you don't do it. Requested in the last status update meeting.