### PR TITLE
Stop clearing table photo filename on null upload

### DIFF
--- a/mff_rams_plugin/configspec.ini
+++ b/mff_rams_plugin/configspec.ini
@@ -9,7 +9,7 @@ hotel_lottery_faq_url = string(default="https://www.furfest.org/attend/hotels/lo
 dealer_payment_days = integer(default=14)
 
 [data_dirs]
-groups_table_photos_dir = string(default="/groups_table_photos")
+groups_table_photos_dir = string(default="groups_table_photos")
 
 [dates]
 art_show_charity_deadline = string(default="2022-11-30")

--- a/mff_rams_plugin/models.py
+++ b/mff_rams_plugin/models.py
@@ -144,7 +144,7 @@ class Group:
 
     @table_photo.setter
     def table_photo(self, value):
-        if not value:
+        if not value or not getattr(value, 'filename'):
             return
 
         import shutil


### PR DESCRIPTION
Should fix the issue where dealers were un-uploading their table photos.