### PR TITLE
Make dealer_payment_due check SignNow doc

### DIFF
--- a/mff_rams_plugin/models.py
+++ b/mff_rams_plugin/models.py
@@ -106,11 +106,16 @@ class Group:
     @property
     def dealer_payment_due(self):
         if self.approved:
-            return self.approved + timedelta(c.DEALER_PAYMENT_DAYS)
+            if c.SIGNNOW_DEALER_FOLDER_ID or self.terms_conditions_doc:
+                if not self.terms_conditions_doc:
+                    return
+                return self.terms_conditions_doc.created + timedelta(c.DEALER_PAYMENT_DAYS)
+            else:
+                return self.approved + timedelta(c.DEALER_PAYMENT_DAYS)
 
     @property
     def dealer_payment_is_late(self):
-        if self.approved:
+        if self.dealer_payment_due:
             return localized_now() > localize_datetime(self.dealer_payment_due)
 
     @presave_adjustment

--- a/mff_rams_plugin/models.py
+++ b/mff_rams_plugin/models.py
@@ -133,8 +133,9 @@ class Group:
             return True
 
     @property
-    def completed_badges(self):
-        return [a for a in self.attendees if not a.is_unassigned and not a.placeholder]
+    def same_email_badges(self):
+        emails = [a.email for a in self.attendees if not a.is_unassigned and not a.placeholder]
+        return len(emails) != len(set(emails))
 
     @property
     def table_photo(self):

--- a/mff_rams_plugin/templates/emails/dealers/approved.html
+++ b/mff_rams_plugin/templates/emails/dealers/approved.html
@@ -2,9 +2,15 @@
 <head></head>
 <body>
 {{ group.name }} has been approved as a {{ c.EVENT_NAME }} Dealer for this coming {{ event_dates() }}!
+{% if group.dealer_payment_due %}
 You can pay the {{ group.cost|format_currency }} you owe using the credit card button
 <a href="{{ c.URL_BASE }}/preregistration/group_members?id={{ group.id }}">on this page</a>.
 Payment is expected by: {{ group.dealer_payment_due|datetime_local }} or your application may be removed and your tables filled by another applicant.
+{% elif c.SIGNNOW_DEALER_FOLDER_ID %}
+Please look out for an email to sign our terms and conditions for vending at {{ c.EVENT_NAME }} in the near future.
+After signing them, you will be able to pay the {{ group.cost|format_currency }} you owe using the credit card button
+<a href="{{ c.URL_BASE }}/preregistration/group_members?id={{ group.id }}">on this page</a>.
+{% endif %}
 
 {% if group.unassigned %}
     <br/> <br/>

--- a/mff_rams_plugin/templates/forms/hotel/room_lottery.html
+++ b/mff_rams_plugin/templates/forms/hotel/room_lottery.html
@@ -34,7 +34,12 @@
         You may have one room in the dealer block for every three <strong>assigned and completed</strong> dealer or dealer assistant badges on your application.
     </p>
 
-    <p>We encourage people from the same dealer group to room together to help accommodate as many people as possible.</p>
+    <p>
+        We encourage people from the same dealer group to room together to help accommodate as many people as possible.
+        {% if application.attendee.group.same_email_badges or True %}
+        If you can, please also <strong>update your dealer assistants's information</strong> to use unique email addresses -- this helps us a lot when processing room awards!
+        {% endif %}
+    </p>
     {% endif %}
 
     {% if show_staff_rates %}

--- a/mff_rams_plugin/templates/forms/hotel/room_lottery.html
+++ b/mff_rams_plugin/templates/forms/hotel/room_lottery.html
@@ -129,6 +129,18 @@
                 <td></td>
                 <td>$229</td>
             </tr>
+            <tr>
+                <th scope="row">Hyatt Centric Chicago O'Hare</th>
+                <td>$167</td>
+                <td>$182</td>
+                <td></td>
+            </tr>
+            <tr>
+                <th scope="row">Sonesta Chicago O'Hare Airport Rosemont</th>
+                <td>$119</td>
+                <td>$129 (2 Queen Beds)</td>
+                <td></td>
+            </tr>
         </tbody>
     </table>
     <div class="form-text mb-4">


### PR DESCRIPTION
If we have to hold off on launching SignNow docs, it doesn't make sense to ask for money two weeks after approval as the dealer might not even be able to pay.

Also updates the approval email to account for this case.