### PR TITLE
Fix email signatures for custom emails

### DIFF
--- a/mff_rams_plugin/templates/emails/dealers/approved.html
+++ b/mff_rams_plugin/templates/emails/dealers/approved.html
@@ -38,6 +38,6 @@ This registration includes:
 
 
 <br />Sincerely,<br />
-{{ c.MARKETPLACE_EMAIL_SIGNATURE }}
+{{ email_signature }}
 </body>
 </html>

--- a/mff_rams_plugin/templates/emails/dealers/declined.txt
+++ b/mff_rams_plugin/templates/emails/dealers/declined.txt
@@ -8,4 +8,4 @@ Please create an account if you do not already have one and include your 10 digi
 
 Alternatively, you can also email hotel@furfest.org.
 
-{{ c.MARKETPLACE_EMAIL_SIGNATURE }}
+{{ email_signature }}

--- a/mff_rams_plugin/templates/emails/dealers/payment_confirmation.html
+++ b/mff_rams_plugin/templates/emails/dealers/payment_confirmation.html
@@ -14,4 +14,4 @@ If you would like to add badges, then please email us as {{ c.MARKETPLACE_EMAIL 
 <br/><br/>
 Badges for preregistered Dealers and Helpers will be available for pickup at the Dealers Den Operations table. Note that a photo ID is required to pick up your badge. The location and hours of the Dealers Den Operations desk will be emailed prior to the event.
 
-{{ c.MARKETPLACE_EMAIL_SIGNATURE }}
+{{ email_signature }}

--- a/mff_rams_plugin/templates/emails/dealers/payment_reminder.txt
+++ b/mff_rams_plugin/templates/emails/dealers/payment_reminder.txt
@@ -4,4 +4,4 @@ Thanks again for registering as a Dealer for this year's {{ c.EVENT_NAME }}.  Ou
 
 You can use the credit card button on your group's page to pay the {{ group.amount_unpaid|format_currency }} that you owe: {{ c.URL_BASE }}/preregistration/group_members?id={{ group.id }}
 
-{{ c.MARKETPLACE_EMAIL_SIGNATURE }}
+{{ email_signature }}

--- a/mff_rams_plugin/templates/emails/dealers/pending_waitlisted.txt
+++ b/mff_rams_plugin/templates/emails/dealers/pending_waitlisted.txt
@@ -12,4 +12,4 @@ Please create an account if you do not already have one and include your 10 digi
 
 Alternatively, you can also email hotel@furfest.org.
 
-{{ c.MARKETPLACE_EMAIL_SIGNATURE }}
+{{ email_signature }}

--- a/mff_rams_plugin/templates/emails/dealers/waitlist_closing.txt
+++ b/mff_rams_plugin/templates/emails/dealers/waitlist_closing.txt
@@ -1,4 +1,4 @@
 {{ group.leader.first_name }}, 
 
 I regret to inform you that the waitlist for {{c.EVENT_NAME}} has expired, and thus your application for dealer space has been declined. We have received many more applications for space than are available, and unfortunately that means I must decline some applications. We hope you will apply again next year. In case you still wish to attend the event, we have converted your badges and you will be able to pay for them at the rate in effect when you applied for dealer space. 
-{{ c.MARKETPLACE_EMAIL_SIGNATURE }}
+{{ email_signature }}

--- a/mff_rams_plugin/templates/emails/placeholders/dealer.txt
+++ b/mff_rams_plugin/templates/emails/placeholders/dealer.txt
@@ -4,4 +4,4 @@ You've been registered for a badge as part of the {{ c.EVENT_NAME }} Dealer's De
 
 Please let us know if you have any questions.
 
-{{ c.MARKETPLACE_EMAIL_SIGNATURE }}
+{{ email_signature }}

--- a/mff_rams_plugin/templates/emails/placeholders/guest.txt
+++ b/mff_rams_plugin/templates/emails/placeholders/guest.txt
@@ -4,4 +4,4 @@ Thanks for coming out to {{ c.EVENT_NAME }} as a Guest!  We've added you to our 
 
 Please let us know if you have any questions.
 
-{{ c.GUEST_EMAIL_SIGNATURE }}
+{{ email_signature }}

--- a/mff_rams_plugin/templates/emails/placeholders/imported_volunteer.txt
+++ b/mff_rams_plugin/templates/emails/placeholders/imported_volunteer.txt
@@ -10,4 +10,4 @@ If you want to return to {{ c.EVENT_NAME }} but don't want to volunteer again, j
 
 Please let us know if you have any questions.
 
-{{ c.STOPS_EMAIL_SIGNATURE }}
+{{ email_signature }}

--- a/mff_rams_plugin/templates/emails/placeholders/panelist.txt
+++ b/mff_rams_plugin/templates/emails/placeholders/panelist.txt
@@ -4,4 +4,4 @@ Thanks for coming out to {{ c.EVENT_NAME }} as a Panelist!  We've added you to o
 
 Please let us know if you have any questions.
 
-{{ c.PEGLEGS_EMAIL_SIGNATURE }}
+{{ email_signature }}

--- a/mff_rams_plugin/templates/emails/placeholders/regular.txt
+++ b/mff_rams_plugin/templates/emails/placeholders/regular.txt
@@ -6,4 +6,4 @@ You may also choose to upgrade your membership at this time, for an additional f
 
 If you have any questions, please email us at registration@furfest.org
 
-{{ c.REGDESK_EMAIL_SIGNATURE }}
+{{ email_signature }}

--- a/mff_rams_plugin/templates/emails/placeholders/reminder.txt
+++ b/mff_rams_plugin/templates/emails/placeholders/reminder.txt
@@ -6,4 +6,4 @@ We need to know whether you're coming, so please let us know by accepting your r
 
 You won't be able to check-in at the event until your registration is complete!
 
-{{ c.REGDESK_EMAIL_SIGNATURE }}
+{{ email_signature }}

--- a/mff_rams_plugin/templates/emails/placeholders/volunteer.txt
+++ b/mff_rams_plugin/templates/emails/placeholders/volunteer.txt
@@ -4,4 +4,4 @@ Thanks for volunteering to help the staff of {{ c.EVENT_NAME }}!  You've been ad
 
 If you have any questions, please email us at registration@furfest.org
 
-{{ c.STOPS_EMAIL_SIGNATURE }}
+{{ email_signature }}

--- a/mff_rams_plugin/templates/emails/reg_workflow/group_confirmation.html
+++ b/mff_rams_plugin/templates/emails/reg_workflow/group_confirmation.html
@@ -23,7 +23,7 @@ You may preassign your badges on your <a href="{{ c.URL_BASE }}/preregistration/
 <p>If you would like to add badges to your group, then please email us as {{ c.MARKETPLACE_EMAIL }}.<br />
 Badges for preregistered Dealers and Helpers will be available for pickup at the Dealers Den Operations table. Note that a photo ID is required to pick up your badge. The location and hours of the Dealers Den Operations desk will be emailed prior to the event.
 </p>
-{{ c.MARKETPLACE_EMAIL_SIGNATURE }}
+{{ email_signature }}
 {% endif %}
 
 </body>

--- a/mff_rams_plugin/templates/emails/reg_workflow/under_18_reminder.txt
+++ b/mff_rams_plugin/templates/emails/reg_workflow/under_18_reminder.txt
@@ -14,4 +14,4 @@ If you have any questions please email registration@furfest.org
 
 We look forward to seeing you at {{ c.EVENT_NAME_AND_YEAR }}!
 
-{{ c.REGDESK_EMAIL_SIGNATURE }}
+{{ email_signature }}


### PR DESCRIPTION
This might be the problem with our emails not updating -- even if not, we should still fix this so that the email signatures aren't blank.